### PR TITLE
adjust regenerate available card check

### DIFF
--- a/DungeonDuell/Assets/DungeonDuell/Script/CardPhase/PlayerDeck.cs
+++ b/DungeonDuell/Assets/DungeonDuell/Script/CardPhase/PlayerDeck.cs
@@ -71,7 +71,7 @@ namespace dungeonduell
                 firstTime = false;
             }
 
-            if (availableCards.Count <= 0) GetPerDistributer();
+            if (availableCards.Count <= deckSize) GetPerDistributer();
         }
 
         private void PickCards()


### PR DESCRIPTION
Simple bug fix. Wenn du alle Card abarbeitet (unwahrscheinlich aber möglich) werden die mögliche Karten nicht neu geneiert da der check dafür nicht ganz richtig war. jetzt gefixt.